### PR TITLE
refactor: Report dates in UTC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
                 with:
                     fetch-depth: 0
 

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/Applicant.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/Applicant.php
@@ -82,9 +82,6 @@ final class Applicant implements ArraySerializable
 				'consumerStatement'        => ArraySerializationConfig::mixedCustomSerializer(),
 				'incomeEstimate'           => ArraySerializationConfig::mixedCustomSerializer(),
 				'ofac'                     => ArraySerializationConfig::mixedCustomSerializer(),
-				'reportRetrievedOn'        => [
-					fn (Carbon $date) => $date->isoFormat('YYYY-MM-DD[T]HH:mm:ss.SSSSSSSZ'),
-				],
 			]
 		);
 	}

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/Applicant/Tradeline.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/Applicant/Tradeline.php
@@ -76,7 +76,7 @@ final class Tradeline implements ArraySerializable
 			[
 				'openClosed'     => ArraySerializationConfig::mixedCustomSerializer(),
 				'paymentPattern' => [
-					fn (array $value)  => implode('', $value),
+					fn (array $value)  => implode('', array_map(fn (PaymentPatternItem $item) => $item->value, $value)),
 					fn (string $value) => array_map(fn (string $item) => PaymentPatternItem::from($item), mb_str_split($value)),
 				],
 			]

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/TransactionsControl/TransactionsControlTracking.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Credit/TransactionsControl/TransactionsControlTracking.php
@@ -23,11 +23,6 @@ final class TransactionsControlTracking implements ArraySerializable
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
 			[],
-			[
-				'transactionTimeStamp' => [
-					fn (Carbon $date) => $date->isoFormat('YYYY-MM-DD[T]HH:mm:ss.SSSZ'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal.php
@@ -44,12 +44,6 @@ final class Criminal implements ArraySerializable
 				'disclaimers' => Disclaimer::class,
 				'identities'  => Identity::class,
 			],
-			[
-				'createdOn' => [
-					// 2021-12-09T08:55:10.9210625-06:00
-					fn (Carbon $date) => $date->isoFormat('YYYY-MM-DD[T]HH:mm:ss.SSSSSSSZ'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity.php
@@ -27,7 +27,7 @@ final class Identity implements ArraySerializable
 		public readonly ?string $age,
 		public readonly ?array $aliases,
 		public readonly ?int $arrestCount,
-		public readonly ?string $birthDate,
+		public readonly ?Carbon $birthDate,
 		public readonly ?string $birthPlace,
 		public readonly ?string $bodyBuild,
 		public readonly ?int $bookingCount,
@@ -81,12 +81,6 @@ final class Identity implements ArraySerializable
 				'idNumbers' => IdNumber::class,
 				'offenses'  => Offense::class,
 			],
-			[
-				'dateTimeModified' => [
-					// 02/18/2020 16:50:15
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY HH:mm:ss'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
@@ -40,6 +40,32 @@ final class IdentityCase implements ArraySerializable
 			[
 				'offenses' => Offense::class,
 			],
+			[
+				'completionDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'dispositionDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'filingDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'statusBeginDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'statusDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'statusEndDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
@@ -40,32 +40,6 @@ final class IdentityCase implements ArraySerializable
 			[
 				'offenses' => Offense::class,
 			],
-			[
-				'completionDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'dispositionDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'filingDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'statusBeginDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'statusDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'statusEndDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/IdentityCase.php
@@ -40,32 +40,6 @@ final class IdentityCase implements ArraySerializable
 			[
 				'offenses' => Offense::class,
 			],
-			[
-				'completionDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'dispositionDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'filingDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'statusBeginDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'statusDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'statusEndDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
@@ -57,36 +57,6 @@ final class Offense implements ArraySerializable
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
 			[],
-			[
-				'offenseDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'chargeDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'statusDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'pleaDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'dispositionDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'dispositionStatusDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-				'sentenceDate' => [
-					// 20200218
-					fn (Carbon $date) => $date->isoFormat('YYYYMMDD'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
@@ -57,6 +57,36 @@ final class Offense implements ArraySerializable
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
 			[],
+			[
+				'offenseDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'chargeDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'statusDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'pleaDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'dispositionDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'dispositionStatusDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'sentenceDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Criminal/Identity/Offense.php
@@ -57,36 +57,6 @@ final class Offense implements ArraySerializable
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
 			[],
-			[
-				'offenseDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'chargeDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'statusDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'pleaDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'dispositionDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'dispositionStatusDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'sentenceDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction.php
@@ -37,12 +37,6 @@ final class Eviction implements ArraySerializable
 				'disclaimers' => 'mixed',
 				'records'     => Record::class,
 			],
-			[
-				'createdOn' => [
-					// 2021-12-09T08:55:10.9210625-06:00
-					fn (Carbon $date) => $date->isoFormat('YYYY-MM-DD[T]HH:mm:ss.SSSSSSSZ'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
@@ -49,16 +49,6 @@ final class Record implements ArraySerializable
 			[
 				'events' => Event::class,
 			],
-			[
-				'filingDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'releaseDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
@@ -49,6 +49,16 @@ final class Record implements ArraySerializable
 			[
 				'events' => Event::class,
 			],
+			[
+				'filingDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'releaseDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record.php
@@ -49,16 +49,6 @@ final class Record implements ArraySerializable
 			[
 				'events' => Event::class,
 			],
-			[
-				'filingDate' => [
-					// 02/18/2020
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY'),
-				],
-				'releaseDate' => [
-					// 02/18/2020
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
@@ -77,16 +77,6 @@ final class Event implements ArraySerializable
 			[
 				'parties' => Party::class,
 			],
-			[
-				'filingDate' => [
-					// 02/18/2020
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY'),
-				],
-				'releaseDate' => [
-					// 02/18/2020
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
@@ -77,16 +77,6 @@ final class Event implements ArraySerializable
 			[
 				'parties' => Party::class,
 			],
-			[
-				'filingDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-				'releaseDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event.php
@@ -77,6 +77,16 @@ final class Event implements ArraySerializable
 			[
 				'parties' => Party::class,
 			],
+			[
+				'filingDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+				'releaseDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
@@ -45,13 +45,6 @@ final class CourtAddress implements ArraySerializable
 	{
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
-			[],
-			[
-				'reportDate' => [
-					// 02/18/2020
-					fn (Carbon $date) => $date->isoFormat('MM/DD/YYYY'),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
@@ -45,6 +45,13 @@ final class CourtAddress implements ArraySerializable
 	{
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
+			[],
+			[
+				'reportDate' => [
+					null,
+					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
+				],
+			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
+++ b/src/TenantCloud/TransUnionSDK/Reports/Data/Eviction/Record/Event/Court/CourtAddress.php
@@ -46,12 +46,6 @@ final class CourtAddress implements ArraySerializable
 		return new ArraySerializationConfig(
 			ArraySerializationConfig::pascalSerializedName(),
 			[],
-			[
-				'reportDate' => [
-					null,
-					fn ($value) => Carbon::parse($value, 'UTC')->setHours(12),
-				],
-			]
 		);
 	}
 }

--- a/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
+++ b/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
@@ -150,8 +150,9 @@ trait MagicArraySerializable
 							}
 
 							if (is_a($type, Carbon::class, true)) {
-								// 2019-10-01T00:00:00
-								return $value->toDateTimeLocalString();
+								/** @var Carbon $value */
+								// 2019-10-01T00:00:00.000000Z
+								return $value->toISOString();
 							}
 
 							if (is_a($type, ArraySerializable::class, true)) {

--- a/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
+++ b/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
@@ -55,7 +55,14 @@ trait MagicArraySerializable
 									return null;
 								}
 
-								return $type::parse($value, 'UTC');
+								$parsed = $type::parse($value, 'UTC');
+
+								// This is a dirty hack to check if time was passed. If it wasn't, it's treated as a date so 12:00:00 is set.
+								if (!preg_match('.*\d+:\d+:\d+', $value)) {
+									$parsed->setHours(12);
+								}
+
+								return $parsed;
 							}
 
 							if (is_a($type, ArraySerializable::class, true)) {

--- a/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
+++ b/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
@@ -58,7 +58,7 @@ trait MagicArraySerializable
 								$parsed = $type::parse($value, 'UTC');
 
 								// This is a dirty hack to check if time was passed. If it wasn't, it's treated as a date so 12:00:00 is set.
-								if (!preg_match('.*\d+:\d+:\d+', $value)) {
+								if (!preg_match('/\d+:\d+:\d+/', $value)) {
 									$parsed->setHours(12);
 								}
 

--- a/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
+++ b/src/TenantCloud/TransUnionSDK/Shared/ArraySerializationHack/MagicArraySerializable.php
@@ -55,7 +55,7 @@ trait MagicArraySerializable
 									return null;
 								}
 
-								return $type::parse($value);
+								return $type::parse($value, 'UTC');
 							}
 
 							if (is_a($type, ArraySerializable::class, true)) {


### PR DESCRIPTION
BREAKING CHANGE: Report dates are now stored and serialized as ISO8601; birthDate field is now a Carbon instance.